### PR TITLE
Edit README & add Vim help documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PlainTasks.vim
 This plugin is an implementation of the PlainTasks format
 (see https://github.com/aziz/PlainTasks) for Vim
 
-to install with Vundle just add the following line your .vimrc and run ":BundleInstall"
+To install with [Vundle](https://github.com/gmarik/Vundle.vim), add the following line to your .vimrc and run ":BundleInstall"
 
 ```
 Bundle 'elentok/plaintasks.vim'
@@ -13,11 +13,14 @@ Bundle 'elentok/plaintasks.vim'
 Keyboard Shortcuts
 ------------------
 
+**Normal-mode**
 ```
 + - create new task
 = - toggle complete
 <C-M> - toggle cancel
 - - archive tasks
+```
+**Insert-mode**
+```
 --<space> - insert a separator line
-
 ```

--- a/doc/plaintasks.txt
+++ b/doc/plaintasks.txt
@@ -1,0 +1,36 @@
+*plaintasks.txt*   An implementation of Sublime's PlainTasks plugin for Vim
+
+CONTENTS                                                   *plaintasks-contents*
+
+   About..........................|plaintasks-about|
+   Usage..........................|plaintasks-filetype|
+   Mappings.......................|plaintasks-mappings|
+
+==============================================================================
+ABOUT                                                         *plaintasks-about*
+
+An opinionated todo-list plugin.
+
+This plugin is an implementation of the PlainTasks format (see
+https://github.com/aziz/PlainTasks) for Vim
+
+==============================================================================
+FILETYPE                                                   *plaintasks-filetype*
+
+Save your todo files with |todo|, |todolist|, |tasks| or |taskpaper| file extensions
+or just name them |TODO| with no extension.
+
+==============================================================================
+MAPPINGS                                                   *plaintasks-mappings*
+
+  *Normal-mode*
+      |+|         Create new task
+      |=|         Toggle complete
+      |<C-M>|     Toggle cancel
+      |-|         Archive tasks
+
+  *Insert-mode*
+      |<--->|     Insert a separator line
+
+==============================================================================
+vim:ft=help:et:ts=2:sw=2:sts=2:norl

--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,6 @@
+plaintasks	plaintasks.txt	/*plaintasks.txt*
+plaintasks-about	plaintasks.txt	/*plaintasks-about*
+plaintasks-contents	plaintasks.txt	/*plaintasks-contents*
+plaintasks-filetype	plaintasks.txt	/*plaintasks-filetype*
+plaintasks-mappings	plaintasks.txt	/*plaintasks-mappings*
+plaintasks.txt	plaintasks.txt	/*plaintasks.txt*


### PR DESCRIPTION
This PR adds `:help` documention so that users can look up Plaintask bindings from within Vim.

The help tags are:
```
:h Plaintasks
:h plaintasks.txt
:h plaintasks-contents
:h plaintasks-filetype
:h plaintasks-mappings
```

I've also updated the README, splitting the bindings into the modes from which they can be triggered.


![screen shot of plaintask help documentation](https://cloud.githubusercontent.com/assets/4262486/16373235/1ed076ac-3c06-11e6-93b8-984f10f35e3d.png)

