### PR TITLE
Add mappings to Visual-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Bundle 'elentok/plaintasks.vim'
 Keyboard Shortcuts
 ------------------
 
-**Normal-mode**
+**Normal-mode / Visual-mode**
 ```
 + - create new task
 = - toggle complete

--- a/doc/plaintasks.txt
+++ b/doc/plaintasks.txt
@@ -23,7 +23,7 @@ or just name them |TODO| with no extension.
 ==============================================================================
 MAPPINGS                                                   *plaintasks-mappings*
 
-  *Normal-mode*
+  *Normal-mode/Visual-mode*
       |+|         Create new task
       |=|         Toggle complete
       |<C-M>|     Toggle cancel

--- a/ftplugin/plaintasks.vim
+++ b/ftplugin/plaintasks.vim
@@ -9,8 +9,9 @@ if exists("b:did_ftplugin")
 endif
 
 nnoremap <buffer> + :call NewTask()<cr>A
-nnoremap <buffer> = :call ToggleComplete()<cr>
-nnoremap <buffer> <C-M> :call ToggleCancel()<cr>
+vnoremap <buffer> + :call NewTask()<cr>
+noremap <buffer> = :call ToggleComplete()<cr>
+noremap <buffer> <C-M> :call ToggleCancel()<cr>
 nnoremap <buffer> - :call ArchiveTasks()<cr>
 abbr -- <c-r>=Separator()<cr>
 


### PR DESCRIPTION
The mappings for `NewTask`, `ToggleComplete`, and `ToggleCancel` now work
in Visual mode.

When creating a new task from `Normal-mode`, as before, the mapping will exit to
`Insert-mode`. When used in `Visual-mode`, it will exit to `Normal`.
![plaintasks-visual-mode](https://cloud.githubusercontent.com/assets/4262486/16674004/7b5eef88-4468-11e6-9137-9b76e62d02dc.gif)

---
Fixes part of issue #7